### PR TITLE
Fix typo or API change from succinctFile to succinctTable.

### DIFF
--- a/spark/README.md
+++ b/spark/README.md
@@ -240,7 +240,7 @@ val cityDataFrame = sqlContext.createDataFrame(cityRDD, citySchema)
 cityDataFrame.write.format("edu.berkeley.cs.succinct.sql").save("/path/to/data")
 
 // Read the Succinct DataFrame from the saved path
-val succinctCities = sqlContext.succinctFile("/path/to/data")
+val succinctCities = sqlContext.succinctTable("/path/to/data")
 
 // Filter and prune
 val bigCities = succinctCities.filter("Area >= 22.0").select("Name").collect


### PR DESCRIPTION
I was taking succinct out for a test drive and found a small typo in the README.