### PR TITLE
Feat spark 1.6.1 scala 2.11

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -24,7 +24,7 @@
     </dependency>
     <dependency>
       <groupId>amplab</groupId>
-      <artifactId>succinct-spark</artifactId>
+      <artifactId>succinct-spark_2.11</artifactId>
       <version>0.1.7-SNAPSHOT</version>
     </dependency>
     <dependency>

--- a/assembly/src/main/assembly/assembly.xml
+++ b/assembly/src/main/assembly/assembly.xml
@@ -15,8 +15,6 @@
       <useProjectArtifact>false</useProjectArtifact>
       <excludes>
         <exclude>org.scala-lang:scala-library</exclude>
-        <exclude>org.apache.spark:spark-core_2.11</exclude>
-        <exclude>org.apache.spark:spark-sql_2.11</exclude>
       </excludes>
       <useTransitiveDependencies>false</useTransitiveDependencies>
     </dependencySet>

--- a/assembly/src/main/assembly/assembly.xml
+++ b/assembly/src/main/assembly/assembly.xml
@@ -15,8 +15,8 @@
       <useProjectArtifact>false</useProjectArtifact>
       <excludes>
         <exclude>org.scala-lang:scala-library</exclude>
-        <exclude>org.apache.spark:spark-core_2.10</exclude>
-        <exclude>org.apache.spark:spark-sql_2.10</exclude>
+        <exclude>org.apache.spark:spark-core_2.11</exclude>
+        <exclude>org.apache.spark:spark-sql_2.11</exclude>
       </excludes>
       <useTransitiveDependencies>false</useTransitiveDependencies>
     </dependencySet>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -71,5 +71,10 @@
       <artifactId>trove4j</artifactId>
       <version>${trove4j.version}</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>net.sf.trove4j</groupId>
       <artifactId>trove4j</artifactId>
-      <version>3.0.3</version>
+      <version>${trove4j.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -75,6 +75,7 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <scalatest.version>2.2.6</scalatest.version>
     <trove4j.version>3.0.3</trove4j.version>
     <jackson.version>2.4.4</jackson.version>
-    <junit.version>3.8.1</junit.version>
+    <junit.version>4.12</junit.version>
     <spark.version>1.6.1</spark.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,13 +36,13 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <scala.version>2.10.4</scala.version>
-    <scala.binary.version>2.10</scala.binary.version>
-    <scalatest.version>2.2.1</scalatest.version>
+    <scala.version>2.11.7</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
+    <scalatest.version>2.2.6</scalatest.version>
     <trove4j.version>3.0.3</trove4j.version>
     <jackson.version>2.4.4</jackson.version>
     <junit.version>3.8.1</junit.version>
-    <spark.version>1.6.0</spark.version>
+    <spark.version>1.6.1</spark.version>
   </properties>
 
   <modules>
@@ -104,18 +104,18 @@
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.10</artifactId>
+      <artifactId>scalatest_2.11</artifactId>
       <version>${scalatest.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.10</artifactId>
+      <artifactId>spark-core_2.11</artifactId>
       <version>${spark.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_2.10</artifactId>
+      <artifactId>spark-sql_2.11</artifactId>
       <version>${spark.version}</version>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -80,43 +80,4 @@
     </plugins>
   </build>
 
-  <!-- Dependencies of all sub-modules -->
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>net.sf.trove4j</groupId>
-      <artifactId>trove4j</artifactId>
-      <version>${trove4j.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.scala-lang</groupId>
-      <artifactId>scala-library</artifactId>
-      <version>${scala.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.11</artifactId>
-      <version>${scalatest.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.11</artifactId>
-      <version>${spark.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_2.11</artifactId>
-      <version>${spark.version}</version>
-    </dependency>
-  </dependencies>
 </project>

--- a/serde/pom.xml
+++ b/serde/pom.xml
@@ -49,9 +49,19 @@
 
   <dependencies>
     <dependency>
+      <groupId>net.sf.trove4j</groupId>
+      <artifactId>trove4j</artifactId>
+      <version>${trove4j.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
     </dependency>
   </dependencies>
 

--- a/serde/pom.xml
+++ b/serde/pom.xml
@@ -62,6 +62,7 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -55,6 +55,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>amplab</groupId>
       <artifactId>succinct-core</artifactId>
       <version>${project.version}</version>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -76,11 +76,13 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_2.11</artifactId>
       <version>${spark.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_2.11</artifactId>
       <version>${spark.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -10,7 +10,7 @@
     <version>0.1.7-SNAPSHOT</version>
   </parent>
 
-  <artifactId>succinct-spark</artifactId>
+  <artifactId>succinct-spark_2.11</artifactId>
   <version>0.1.7-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Succinct-Spark</name>
@@ -50,7 +50,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.10</artifactId>
+      <artifactId>scalatest_2.11</artifactId>
       <version>${scalatest.version}</version>
       <scope>test</scope>
     </dependency>
@@ -74,12 +74,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.10</artifactId>
+      <artifactId>spark-core_2.11</artifactId>
       <version>${spark.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_2.10</artifactId>
+      <artifactId>spark-sql_2.11</artifactId>
       <version>${spark.version}</version>
     </dependency>
   </dependencies>

--- a/spark/src/main/scala/edu/berkeley/cs/succinct/kv/impl/SuccinctKVRDDImpl.scala
+++ b/spark/src/main/scala/edu/berkeley/cs/succinct/kv/impl/SuccinctKVRDDImpl.scala
@@ -88,7 +88,7 @@ class SuccinctKVRDDImpl[K: ClassTag] private[succinct](
         } else {
           Array.empty
         }
-      }, partitions, allowLocal = true)
+      }, partitions)
     results.flatten.toMap
   }
 

--- a/spark/src/main/scala/edu/berkeley/cs/succinct/sql/SuccinctTablePartition.scala
+++ b/spark/src/main/scala/edu/berkeley/cs/succinct/sql/SuccinctTablePartition.scala
@@ -68,7 +68,7 @@ class SuccinctTablePartition(
     succinctIndexedFile.writeToStream(dataOutputStream)
   }
 
-  override def estimatedSize: Long = {
+  override val estimatedSize: Long = {
     succinctIndexedFile.getSuccinctIndexedFileSize + SizeEstimator.estimate(succinctSerDe)
   }
 }


### PR DESCRIPTION
changes:
* upgrade to scala 2.11, because scala 2.10 is getting old and will be deprecated in spark 2.0 and likely dropped in spark 2.1
* bump in patch version for spark
* make sure succinct-spark artifact name has a scala binary version in it
* remove dependencies for all sub-modules from root pom,  since they ended up being actual dependencies for all sub-project artifacts when published and thats no good (succinct-core should not depend on spark for example)
* make spark dependencies provided
* remove deprecated invocation of runJob (which breaks in spark 2)

note that i had to change estimatedSize from a def to a val when switching to scala 2.11, i am not 100% sure why. but when i leave it a def it gets into an infinite loop and a stack overflow. looks like this:
```
at org.apache.spark.util.SizeEstimator$.visitSingleObject(SizeEstimator.scala:219)
	at org.apache.spark.util.SizeEstimator$.org$apache$spark$util$SizeEstimator$$estimate(SizeEstimator.scala:203)
	at org.apache.spark.util.SizeEstimator$.estimate(SizeEstimator.scala:70)
	at org.apache.spark.succinct.sql.SuccinctTablePartition.estimatedSize(SuccinctTablePartition.scala:72)
	at org.apache.spark.util.SizeEstimator$.visitSingleObject(SizeEstimator.scala:219)
	at org.apache.spark.util.SizeEstimator$.org$apache$spark$util$SizeEstimator$$estimate(SizeEstimator.scala:203)
	at org.apache.spark.util.SizeEstimator$.estimate(SizeEstimator.scala:70)
	at org.apache.spark.succinct.sql.SuccinctTablePartition.estimatedSize(SuccinctTablePartition.scala:72)
	at org.apache.spark.util.SizeEstimator$.visitSingleObject(SizeEstimator.scala:219)
	at org.apache.spark.util.SizeEstimator$.org$apache$spark$util$SizeEstimator$$estimate(SizeEstimator.scala:203)
	at org.apache.spark.util.SizeEstimator$.estimate(SizeEstimator.scala:70)
	at org.apache.spark.succinct.sql.SuccinctTablePartition.estimatedSize(SuccinctTablePartition.scala:72)
	at org.apache.spark.util.SizeEstimator$.visitSingleObject(SizeEstimator.scala:219)
	at org.apache.spark.util.SizeEstimator$.org$apache$spark$util$SizeEstimator$$estimate(SizeEstimator.scala:203)
	at org.apache.spark.util.SizeEstimator$.estimate(SizeEstimator.scala:70)
[and many more lines just like this]
```

and the error:
```
 Cause: java.lang.StackOverflowError:
  at org.apache.spark.util.SizeEstimator$.org$apache$spark$util$SizeEstimator$$estimate(SizeEstimator.scala:201)
  at org.apache.spark.util.SizeEstimator$$anonfun$sampleArray$1.apply$mcVI$sp(SizeEstimator.scala:284)
  at scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:166)
  at org.apache.spark.util.SizeEstimator$.sampleArray(SizeEstimator.scala:276)
  at org.apache.spark.util.SizeEstimator$.visitArray(SizeEstimator.scala:260)
  at org.apache.spark.util.SizeEstimator$.visitSingleObject(SizeEstimator.scala:211)
  at org.apache.spark.util.SizeEstimator$.org$apache$spark$util$SizeEstimator$$estimate(SizeEstimator.scala:203)
  at org.apache.spark.util.SizeEstimator$$anonfun$sampleArray$1.apply$mcVI$sp(SizeEstimator.scala:284)
  at scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:166)
  at org.apache.spark.util.SizeEstimator$.sampleArray(SizeEstimator.scala:276)
```