### PR TITLE
<groupId>edu.berkeley.cs.succinct</groupId> replaced by <groupId>amplab</groupId> in README of core module

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -15,7 +15,7 @@ using Maven by adding the following dependency information to your pom.xml file:
 
 ```xml
 <dependency>
-    <groupId>edu.berkeley.cs.succinct</groupId>
+    <groupId>amplab</groupId>
     <artifactId>succinct-core</artifactId>
     <version>0.1.8</version>
 </dependency>


### PR DESCRIPTION
&lt;groupId>edu.berkeley.cs.succinct&lt;/groupId> replaced by &lt;groupId>amplab&lt;/groupId> in README of core module